### PR TITLE
make kaboom a dependancy not peerdependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "keywords": [],
     "author": "",
     "license": "ISC",
-    "peerDependencies": {
+    "dependencies": {
         "kaboom": "^3000.1.17"
     },
     "devDependencies": {


### PR DESCRIPTION
this gives it free advertisement on npm and helps package managers not think there is 0 dependancies